### PR TITLE
release claim for free releases

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -19,7 +19,7 @@ nina_v2 = "nina2DQvAA8Sa9rxG72swBcNNDYQxdWGojzwDk9yn2q"
 url = "https://api.apr.dev"
 
 [provider]
-cluster = "mainnet"
+cluster = "devnet"
 wallet = "/Users/michaelpollard/.config/solana/nina.json"
 
 [scripts]

--- a/programs/nina-v2/src/errors.rs
+++ b/programs/nina-v2/src/errors.rs
@@ -12,4 +12,6 @@ pub enum NinaError {
     ArithmeticError,
     #[msg("Delegated Payer Mismatch")]
     DelegatedPayerMismatch,
+    #[msg("Release Claim not free")]
+    ReleaseClaimNotFree,
 }

--- a/programs/nina-v2/src/instructions/mod.rs
+++ b/programs/nina-v2/src/instructions/mod.rs
@@ -3,9 +3,11 @@ pub mod release_purchase;
 pub mod release_init_and_purchase;
 pub mod release_update;
 pub mod release_close;
+pub mod release_claim;
 
 pub use release_init_v2::*;
 pub use release_purchase::*;
 pub use release_init_and_purchase::*;
 pub use release_update::*;
 pub use release_close::*;
+pub use release_claim::*;

--- a/programs/nina-v2/src/instructions/release_claim.rs
+++ b/programs/nina-v2/src/instructions/release_claim.rs
@@ -1,0 +1,158 @@
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token::{Token, Transfer},
+    token_interface::{
+        Token2022,
+        Mint,
+        TokenAccount,
+    },
+    token_2022::{MintTo, mint_to},
+};
+
+use crate::state::ReleaseV2;
+use crate::errors::NinaError;
+use crate::utils::id_account_key;
+
+const BASIS_POINTS: u64 = 1_000_000;
+const ONE_USDC: u64 = 10_000_000;
+const TEN_PERCENT: u64 = 100_000;
+
+#[derive(Accounts)]
+#[instruction(
+  amount: u64,
+  release_signer_bump: u8,
+)]
+pub struct ReleaseClaim<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    /// CHECK: can be any account
+    #[account(mut)]
+    pub receiver: UncheckedAccount<'info>,
+    #[account(
+        seeds = [b"nina-release", mint.key().as_ref()],
+        bump,
+    )]
+    pub release: Account<'info, ReleaseV2>,
+    /// CHECK: This is safe because it is derived from release which is checked above
+    #[account(
+        seeds = [release.key().as_ref()],
+        bump,
+    )]
+    pub release_signer: UncheckedAccount<'info>,
+    #[account(
+      mut,
+      constraint = mint.key() == release.mint,
+    )]
+    pub mint: Box<InterfaceAccount<'info, Mint>>,
+    #[account(
+      constraint = payment_mint.key() == release.payment_mint,
+    )]
+    pub payment_mint: Box<InterfaceAccount<'info, Mint>>,
+    #[account(
+      mut,
+      constraint = payment_token_account.mint == release.payment_mint,
+      constraint = payment_token_account.owner == payer.key(),
+    )]
+    pub payment_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
+    #[account(
+      mut,
+      constraint = royalty_token_account.key() == release.royalty_token_account,
+      constraint = royalty_token_account.mint == release.payment_mint,
+    )]
+    pub royalty_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
+    #[account(
+        init_if_needed,
+        payer = payer,
+        associated_token::token_program = token_2022_program,
+        associated_token::mint = mint,
+        associated_token::authority = receiver,
+    )]
+    pub receiver_release_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
+    ///TODO: CHECK THAT ADDRESS === EXPECTED CRS ADDRESS
+    // #[account(
+    //   mut,
+    //   constraint = crs_token_account.mint == release.payment_mint,
+    // )]
+    // pub crs_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
+    pub system_program: Program<'info, System>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub token_program: Program<'info, Token>,
+    pub token_2022_program: Program<'info, Token2022>,
+}
+
+pub fn handler<'c: 'info, 'info>(
+    ctx: Context<'_, '_, 'c, 'info, ReleaseClaim<'info>>,
+    amount: u64,
+    release_signer_bump: u8,
+) -> Result<()> {
+
+    if ctx.accounts.release.price != 0 {
+        return Err(error!(NinaError::ReleaseClaimNotFree));
+    }
+
+    if ctx.accounts.payer.key() != ctx.accounts.receiver.key() {
+        #[cfg(feature = "is-test")]
+        if ctx.accounts.payer.key() != id_account_key() {
+            return Err(error!(NinaError::DelegatedPayerMismatch));
+        }
+    }
+
+    validate_purchase(&ctx.accounts.release, &ctx.accounts.mint, amount)?;
+            
+    mint_release_token(
+        &ctx.accounts.mint,
+        &ctx.accounts.receiver_release_token_account,
+        &ctx.accounts.release_signer,
+        &ctx.accounts.release,
+        &ctx.accounts.token_2022_program,
+        release_signer_bump,
+    )?;
+    
+    Ok(())
+}
+
+pub fn validate_purchase<'info>(
+    release: &Account<'info, ReleaseV2>,
+    mint: &InterfaceAccount<'info, Mint>,
+    amount: u64,
+) -> Result<()> {
+    if amount != release.price {
+        return Err(error!(NinaError::ReleasePurchaseWrongAmount));
+    }
+
+    if mint.supply >= release.total_supply {
+        return Err(error!(NinaError::ReleasePurchaseSoldOut));
+    }
+
+    Ok(())
+}
+
+pub fn mint_release_token<'info>(
+    mint: &InterfaceAccount<'info, Mint>,
+    receiver_release_token_account: &InterfaceAccount<'info, TokenAccount>,
+    release_signer: &UncheckedAccount<'info>,
+    release: &Account<'info, ReleaseV2>,
+    token_2022_program: &Program<'info, Token2022>,
+    release_signer_bump: u8,
+) -> Result<()> {
+    let cpi_accounts_mint_to = MintTo {
+        mint: mint.to_account_info(),
+        to: receiver_release_token_account.to_account_info(),
+        authority: release_signer.to_account_info(),
+    };
+
+    let seeds = &[
+        release.to_account_info().key.as_ref(),
+        &[release_signer_bump],
+    ];
+    let signer = &[&seeds[..]];
+    
+    let cpi_ctx_mint_to = CpiContext::new_with_signer(
+        token_2022_program.to_account_info(),
+        cpi_accounts_mint_to,
+        signer
+    );
+    
+    mint_to(cpi_ctx_mint_to, 1)
+}

--- a/programs/nina-v2/src/lib.rs
+++ b/programs/nina-v2/src/lib.rs
@@ -40,6 +40,14 @@ pub mod nina_v2 {
         )
     }
 
+    pub fn release_claim<'c: 'info, 'info>(
+        ctx: Context<'_, '_, 'c, 'info, ReleaseClaim<'info>>,
+        amount: u64,
+        release_signer_bump: u8,
+    ) -> Result<()> {
+        instructions::release_claim::handler(ctx, amount, release_signer_bump)
+    }
+
     pub fn release_init_and_purchase<'c: 'info, 'info>(
         ctx: Context<'_, '_, 'c, 'info, ReleaseInitAndPurchase<'info>>,
         release_signer_bump: u8,


### PR DESCRIPTION
ok - the coinflow fix from last week assumed that the payer of a releasePurchase tx was always the user

in the case of free releases this has to be the beam wallet

the simplest solution was to make a new claim instruction on v2 program with the correct constraints

after doing this is realized that we already have a claim instruction in v1 - this is what we use for release codes, but in v2 there are no release codes...

since we will be getting rid of free releases with the crs i think it is fine to no longer have free releases on v2 - this work here is just temporary so free releases work until we get to CRS.  im not too happy with this all but is a hacky solution to a tmeporary problem.

corresponding backend PRs:
https://github.com/nina-protocol/id-server/pull/579
https://github.com/nina-protocol/nina-indexer/pull/948

A Note:

i tried to do this on the frontend by having the frontend build the txs but this was not without issues [also along the way i realized that we are using a dangerous pattern where the frontend sends arbitrary txs and the backend sings them.  we should instead have the backend receive a normal POST request, check if it is valid, then build the tx from scratch on backend complete with backend signature and then send to the frontend to sign and submit]
